### PR TITLE
Return currentMessage in getMessage if nothing has changed

### DIFF
--- a/burp/BurpExtender.java
+++ b/burp/BurpExtender.java
@@ -218,7 +218,7 @@ public class BurpExtender implements IBurpExtender, IMessageEditorTabFactory, IT
                     return currentMessage;
                 }
             }
-            return null;
+            return currentMessage;
         }
 
         @Override


### PR DESCRIPTION
This fixes a bug in which if we click on send multiple times in Burp Repeater window and content of json hasn't changed, the request won't be sent